### PR TITLE
Fix PR block because CI does not run on `terraform-docs` commit

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,16 +24,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Setup SSH agent with deploy key
-        uses: webfactory/ssh-agent@v0.9.0
-        with:
-          ssh-private-key: ${{ secrets.TERRAFORM_DOCS_DEPLOY_KEY }}
-
       - name: Checkout code
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.ref }}
-          persist-credentials: false
+          ssh-key: ${{ secrets.TERRAFORM_DOCS_DEPLOY_KEY }}
 
       - name: Render terraform docs and push changes back to PR
         uses: terraform-docs/gh-actions@main

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,11 +24,16 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Setup SSH agent with deploy key
+        uses: webfactory/ssh-agent@v0.9.0
+        with:
+          ssh-private-key: ${{ secrets.TERRAFORM_DOCS_DEPLOY_KEY }}
+
       - name: Checkout code
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.ref }}
-          token: ${{ secrets.TERRAFORM_DOCS_DEPLOY_KEY || secrets.GITHUB_TOKEN }}
+          persist-credentials: false
 
       - name: Render terraform docs and push changes back to PR
         uses: terraform-docs/gh-actions@main

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,9 +19,59 @@ permissions:
   pull-requests: write
 
 jobs:
+  terraform-docs:
+    # Generates terraform documentation using terraform-docs
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          token: ${{ secrets.TERRAFORM_DOCS_PAT || secrets.GITHUB_TOKEN }}
+
+      - name: Render terraform docs and push changes back to PR
+        uses: terraform-docs/gh-actions@main
+        with:
+          working-dir: .
+          config-file: .terraform-docs.yml
+          git-push: "true"
+
+  check-docs-changes:
+    # Checks if terraform-docs created a new commit in this workflow run
+    # Fails fast to prevent wasting resources on expensive tests
+    needs: terraform-docs
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          fetch-depth: 0
+
+      - name: Check if terraform-docs created a commit in this run
+        env:
+          GITHUB_SHA_BEFORE: ${{ github.event.pull_request.head.sha }}
+        run: |
+          # Get the current HEAD commit SHA after terraform-docs ran
+          CURRENT_SHA=$(git rev-parse HEAD)
+
+          echo "SHA before workflow: $GITHUB_SHA_BEFORE"
+          echo "SHA after terraform-docs: $CURRENT_SHA"
+
+          # If the SHAs are different, terraform-docs created a new commit
+          if [[ "$GITHUB_SHA_BEFORE" != "$CURRENT_SHA" ]]; then
+            echo "terraform-docs created a new commit in this run. Failing fast to trigger new workflow on the new commit."
+            exit 1
+          else
+            echo "No new commit from terraform-docs. Proceeding with tests."
+          fi
+
   code-quality-checks:
     # Runs the pre-commit checks  (see `.pre-commit-config.yaml`)
     # and runs `terragrunt plan` to ensure the IaC configuration is valid
+    needs: [terraform-docs, check-docs-changes]
     runs-on: ubuntu-latest
 
     steps:
@@ -126,19 +176,3 @@ jobs:
         if: steps.check-label-skip.outputs.label_present == 'false'
         run: go test -v ./tests/... -timeout 30m
 
-  terraform-docs:
-    # Generates terraform documentation using terraform-docs
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.ref }}
-
-      - name: Render terraform docs and push changes back to PR
-        uses: terraform-docs/gh-actions@main
-        with:
-          working-dir: .
-          config-file: .terraform-docs.yml
-          git-push: "true"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,7 +28,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.ref }}
-          token: ${{ secrets.TERRAFORM_DOCS_PAT || secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.TERRAFORM_DOCS_DEPLOY_KEY || secrets.GITHUB_TOKEN }}
 
       - name: Render terraform docs and push changes back to PR
         uses: terraform-docs/gh-actions@main

--- a/bootstrap/enable_tg_github_actions/terragrunt.stack.hcl
+++ b/bootstrap/enable_tg_github_actions/terragrunt.stack.hcl
@@ -2,6 +2,7 @@ locals {
   version = "main"
 
   github_repo_name = "terragrunt-template-catalog-aws"
+  github_token     = get_env("TF_VAR_github_token")
 }
 
 stack "enable_tg_github_actions" {
@@ -11,7 +12,7 @@ stack "enable_tg_github_actions" {
     version          = local.version
     github_username  = "ConsciousML"
     github_repo_name = local.github_repo_name
-    github_token     = get_env("TF_VAR_github_token")
+    github_token     = local.github_token
     iam_role_name    = "github-actions-terragrunt-role"
     policy_arns = [
       "arn:aws:iam::aws:policy/AmazonEC2FullAccess",
@@ -28,5 +29,20 @@ stack "enable_tg_github_actions" {
     deploy_key_repositories = [local.github_repo_name]
     deploy_key_secret_names = ["DEPLOY_KEY_TG_CATALOG"]
     deploy_key_title        = "Terragrunt Catalog Deploy Key"
+  }
+}
+
+unit "deploy_key_terraform_docs" {
+  source = "git::git@github.com:ConsciousML/terragrunt-template-catalog-aws.git//units/deploy_key/?ref=${local.version}"
+  path   = "terraform_docs_deploy_key"
+
+  values = {
+    version            = local.version
+    github_token       = local.github_token
+    repositories       = [local.github_repo_name]
+    current_repository = local.github_repo_name
+    secret_names       = ["TERRAFORM_DOCS_DEPLOY_KEY"]
+    deploy_key_title   = "Terraform Docs Deploy Key"
+    read_only          = false
   }
 }

--- a/modules/deploy_key/README.md
+++ b/modules/deploy_key/README.md
@@ -2,6 +2,7 @@
 # Deploy Key Module
 
 This module creates SSH deploy keys for GitHub repository access.
+Deploy keys are SSH keys that grant access to a specific repository (usually read-only, but can be read-write).
 
 ## Requirements
 

--- a/modules/deploy_key/README.md
+++ b/modules/deploy_key/README.md
@@ -34,6 +34,7 @@ Deploy keys are SSH keys that grant access to a specific repository (usually rea
 | <a name="input_current_repository"></a> [current\_repository](#input\_current\_repository) | GitHub repository name (format: 'repo-name') where the GitHub Actions secrets will be stored | `string` | n/a | yes |
 | <a name="input_deploy_key_title"></a> [deploy\_key\_title](#input\_deploy\_key\_title) | Human-readable title for the deploy key as it appears in GitHub repository settings | `string` | `"Terragrunt Deploy Key"` | no |
 | <a name="input_github_token"></a> [github\_token](#input\_github\_token) | GitHub personal access token with 'repo' and 'admin:repo\_hook' permissions. Required to create deploy keys and manage repository settings | `string` | n/a | yes |
+| <a name="input_read_only"></a> [read\_only](#input\_read\_only) | Whether the deploy key should be read-only (true) or have write access (false). For security, defaults to read-only. | `bool` | `true` | no |
 | <a name="input_repositories"></a> [repositories](#input\_repositories) | List of GitHub repository names (format: 'repo-name') where deploy keys will be added for secure access | `list(string)` | n/a | yes |
 | <a name="input_secret_names"></a> [secret\_names](#input\_secret\_names) | List of GitHub Actions secret names for storing private keys. Must correspond 1:1 with the repositories list (same order) | `list(string)` | n/a | yes |
 

--- a/modules/deploy_key/header.md
+++ b/modules/deploy_key/header.md
@@ -1,3 +1,4 @@
 # Deploy Key Module
 
 This module creates SSH deploy keys for GitHub repository access.
+Deploy keys are SSH keys that grant access to a specific repository (usually read-only, but can be read-write).

--- a/modules/deploy_key/main.tf
+++ b/modules/deploy_key/main.tf
@@ -13,7 +13,7 @@ resource "github_repository_deploy_key" "deploy_key" {
   title      = var.deploy_key_title
   repository = each.key
   key        = tls_private_key.deploy_key[each.key].public_key_openssh
-  read_only  = true
+  read_only  = var.read_only
 }
 
 # Add the private key of each deploy key to the current repository

--- a/modules/deploy_key/variables.tf
+++ b/modules/deploy_key/variables.tf
@@ -24,3 +24,9 @@ variable "deploy_key_title" {
   type        = string
   default     = "Terragrunt Deploy Key"
 }
+
+variable "read_only" {
+  description = "Whether the deploy key should be read-only (true) or have write access (false). For security, defaults to read-only."
+  type        = bool
+  default     = true
+}

--- a/modules/github_secrets/README.md
+++ b/modules/github_secrets/README.md
@@ -1,7 +1,7 @@
 <!-- BEGIN_TF_DOCS -->
 # GitHub Secrets Module
 
-This module creates GitHub Actions secrets `AWS_REGION` and `AWS_ROLE_ARN`. These secrets are retrieved in GitHub Actions workflows for authentication with AWS.
+This module creates GitHub Actions secrets `AWS_REGION` and `AWS_ROLE_ARN`. These secrets are retrieved in GitHub Actions workflows for authentication with Amazon Web Services (AWS)
 
 ## Requirements
 

--- a/modules/github_secrets/header.md
+++ b/modules/github_secrets/header.md
@@ -1,3 +1,3 @@
 # GitHub Secrets Module
 
-This module creates GitHub Actions secrets `AWS_REGION` and `AWS_ROLE_ARN`. These secrets are retrieved in GitHub Actions workflows for authentication with AWS.
+This module creates GitHub Actions secrets `AWS_REGION` and `AWS_ROLE_ARN`. These secrets are retrieved in GitHub Actions workflows for authentication with Amazon Web Services (AWS)

--- a/modules/iam_policies/README.md
+++ b/modules/iam_policies/README.md
@@ -1,7 +1,7 @@
 <!-- BEGIN_TF_DOCS -->
 # Iam Policies Module
 
-This module creates and attaches policies to a IAM role.
+This module creates and attaches policies to a IAM role
 
 ## Requirements
 

--- a/modules/iam_policies/header.md
+++ b/modules/iam_policies/header.md
@@ -1,3 +1,3 @@
 # Iam Policies Module
 
-This module creates and attaches policies to a IAM role.
+This module creates and attaches policies to a IAM role

--- a/modules/oidc_provider/README.md
+++ b/modules/oidc_provider/README.md
@@ -1,7 +1,7 @@
 <!-- BEGIN_TF_DOCS -->
 # AWS OpenID Connect (OIDC) Module
 
-This module creates and configures an OIDC provider in AWS to connect GitHub Actions with AWS
+This module creates or retrieves an existing OIDC provider in AWS to connect GitHub Actions with AWS
 
 ## Requirements
 

--- a/modules/oidc_provider/README.md
+++ b/modules/oidc_provider/README.md
@@ -1,7 +1,11 @@
 <!-- BEGIN_TF_DOCS -->
 # AWS OpenID Connect (OIDC) Module
 
-This module creates or retrieves an existing OIDC provider in AWS to connect GitHub Actions with AWS
+This module creates or retrieves an existing OIDC provider in AWS to connect GitHub Actions with AWS.
+
+The `create` argument is crucial. If this module was used using `create=true`, subsequent use of this module must use `create=false`.
+
+AWS does not allows to create two OIDC providers with the same url.
 
 ## Requirements
 

--- a/modules/oidc_provider/header.md
+++ b/modules/oidc_provider/header.md
@@ -1,3 +1,3 @@
 # AWS OpenID Connect (OIDC) Module
 
-This module creates and configures an OIDC provider in AWS to connect GitHub Actions with AWS
+This module creates or retrieves an existing OIDC provider in AWS to connect GitHub Actions with AWS

--- a/modules/oidc_provider/header.md
+++ b/modules/oidc_provider/header.md
@@ -1,3 +1,7 @@
 # AWS OpenID Connect (OIDC) Module
 
-This module creates or retrieves an existing OIDC provider in AWS to connect GitHub Actions with AWS
+This module creates or retrieves an existing OIDC provider in AWS to connect GitHub Actions with AWS.
+
+The `create` argument is crucial. If this module was used using `create=true`, subsequent use of this module must use `create=false`.
+
+AWS does not allows to create two OIDC providers with the same url.

--- a/modules/vpc/README.md
+++ b/modules/vpc/README.md
@@ -1,7 +1,7 @@
 <!-- BEGIN_TF_DOCS -->
 # VPC Module
 
-This module creates and configures a Virtual Private Cloud network.
+This module creates and configures a Virtual Private Cloud network
 
 ## Requirements
 

--- a/modules/vpc/README.md
+++ b/modules/vpc/README.md
@@ -1,7 +1,7 @@
 <!-- BEGIN_TF_DOCS -->
 # VPC Module
 
-This module creates and configures a Virtual Private Cloud network
+This module creates and configures a Virtual Private Cloud network.
 
 ## Requirements
 

--- a/stacks/enable_tg_github_actions/terragrunt.stack.hcl
+++ b/stacks/enable_tg_github_actions/terragrunt.stack.hcl
@@ -56,5 +56,6 @@ unit "deploy_key" {
     current_repository = values.github_repo_name
     secret_names       = values.deploy_key_secret_names
     deploy_key_title   = values.deploy_key_title
+    read_only          = true
   }
 }

--- a/units/deploy_key/terragrunt.hcl
+++ b/units/deploy_key/terragrunt.hcl
@@ -12,4 +12,5 @@ inputs = {
   secret_names       = values.secret_names
   current_repository = values.current_repository
   deploy_key_title   = values.deploy_key_title
+  read_only          = values.read_only
 }


### PR DESCRIPTION
Closes #23 

- Move terraform-docs job to run first with PAT token support
- Add check-docs-changes job to fail fast when docs are updated
- Update code-quality-checks to depend on both preceding jobs